### PR TITLE
kopiaindexer operates on a single manifest file

### DIFF
--- a/comment_skipper.go
+++ b/comment_skipper.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+)
+
+const (
+	sklStartOrNl = 0
+	sklOther     = 1
+)
+
+func SkipCommentLines(rd *bufio.Reader) error {
+	state := sklStartOrNl
+	for {
+		r, _, err := rd.ReadRune()
+		if err != nil {
+			// TODO(rjk): Consider better error annotations?
+			return err
+		}
+
+		switch state {
+		case sklStartOrNl:
+			if r == '{' {
+				rd.UnreadRune()
+				return nil
+			} else {
+				state = sklOther
+			}
+		case sklOther:
+			if r == '\n' {
+				state = sklStartOrNl
+			}
+		}
+	}
+}

--- a/comment_skipper_test.go
+++ b/comment_skipper_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCommentSkipper(t *testing.T) {
+	for _, k := range []struct {
+		input string
+		want  string
+	}{
+
+		{
+			input: "{",
+			want:  "{",
+		},
+		{
+			input: "// foo\n{",
+			want:  "{",
+		},
+	} {
+		buffy := bufio.NewReader(strings.NewReader(k.input))
+
+		SkipCommentLines(buffy)
+		rest, err := io.ReadAll(buffy)
+
+		if err != nil {
+			t.Errorf("reading the rest didn't work: %v", err)
+		}
+
+		if got, want := string(rest), k.want; got != want {
+			t.Errorf("fooey! got %v, want %v", got, want)
+		}
+
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"log"
 	"os"
 	"os/exec"
@@ -12,8 +13,48 @@ import (
 func main() {
 	log.Println("foo")
 
+	var kID = "";
+	flag.StringVar(&kID, "manifest", "", "Specify a manifest id");
+	flag.Parse();
+
+
 	// Get the list of snapshots.
 	cmd := exec.Command("kopia", "snapshot", "list", "-a", "--json")
+	if (len(kID) > 0) {
+		log.Println("Processing single manifest", kID)
+		//cmd = exec.Command("kopia", "manifest", "show", kID)
+		cmd = exec.Command("catmanifest", kID)
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			log.Fatal(err)
+		}
+
+		dec := json.NewDecoder(stdout)
+		dec.DisallowUnknownFields()
+
+		var manifest cli.SnapshotManifest
+		if err := dec.Decode(&manifest); err != nil {
+			log.Fatal(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			log.Fatal(err)
+		}
+
+		k := manifest;
+		log.Println(k.ID, k.Source.String())
+
+		// TODO(rjk): This could be parallelized.
+		escapedsource := pathUrlEscape(k.Source.String())
+		log.Println("List snapshot", k.RootEntry.ObjectID);
+		listSnapshot(kID, escapedsource)
+		return;
+	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Modify the kopiaindexer program to handle a single manifest file at a time with usage like so:

```shell
kopiaindexer <manifestfile>
```

where `<manifestfile>` is the result of a previous call to `kopia manifest show <manifest>`
